### PR TITLE
feat: spectral regions via arete-graph-utils

### DIFF
--- a/backend/api/regions.py
+++ b/backend/api/regions.py
@@ -1,0 +1,287 @@
+"""Spectral region partitioning of the EVE Frontier galaxy graph.
+
+Uses `arete-graph-utils.spectral_communities` to partition the background
+systems into k natural regions via recursive Fiedler bisection. This gives
+a parameter-free, reproducible "what are the natural clusters here"
+answer without tuning modularity thresholds or resolution parameters.
+
+The graph is built from whichever signal is available:
+  1. If gate topology is provided (e.g., from WatchTower /topology) we use
+     those edges — this is the "real" stargate connectivity.
+  2. Otherwise we fall back to a k-nearest-neighbors proximity graph
+     in the 2D (x, z) plane of the galaxy map. This gives spatially
+     coherent regions without requiring live gate data.
+
+Results are cached for 1 hour because the computation is O(|V|³) in the
+worst case on a dense graph, and the underlying system set changes at
+most hourly (via the static_data_loop).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import time
+from typing import TYPE_CHECKING
+
+import networkx as nx
+from arete_graph_utils import spectral_communities
+from fastapi import APIRouter, Query, Request
+
+if TYPE_CHECKING:
+    import sqlite3
+    from collections.abc import Iterable
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/map/regions", tags=["regions"])
+
+# Cache: (k, graph_kind) -> (timestamp, result_dict)
+_region_cache: dict[tuple[int, str], tuple[float, dict]] = {}
+_REGION_CACHE_TTL = 3600  # 1 hour
+
+
+def _get_db(request: Request) -> sqlite3.Connection:
+    return request.app.state.db
+
+
+def build_knn_graph(
+    systems: list[dict],
+    k: int = 3,
+) -> nx.Graph:
+    """Build a k-nearest-neighbors proximity graph on (x, z) coordinates.
+
+    Args:
+        systems: List of dicts with keys `system_id`, `x`, `z`.
+        k: Number of nearest neighbors per node.
+
+    Returns:
+        Undirected `networkx.Graph` with system_id as node label.
+    """
+    g = nx.Graph()
+    for s in systems:
+        g.add_node(s["system_id"], x=s["x"], z=s["z"])
+
+    if len(systems) < 2:
+        return g
+
+    k = max(1, min(k, len(systems) - 1))
+
+    # O(n²) brute-force neighbor search — fine for 10K-30K systems at cache rate
+    for i, s in enumerate(systems):
+        sx, sz = s["x"], s["z"]
+        dists: list[tuple[float, str]] = []
+        for j, t in enumerate(systems):
+            if i == j:
+                continue
+            dx = t["x"] - sx
+            dz = t["z"] - sz
+            # Use squared distance to avoid sqrt until needed
+            dists.append((dx * dx + dz * dz, t["system_id"]))
+        dists.sort(key=lambda pair: pair[0])
+        for _, neighbor_id in dists[:k]:
+            g.add_edge(s["system_id"], neighbor_id)
+    return g
+
+
+def build_gate_graph(
+    systems: list[dict],
+    gate_edges: Iterable[tuple[str, str]],
+) -> nx.Graph:
+    """Build a gate-topology graph from explicit edges.
+
+    Systems without any gate edges remain as isolated nodes in the graph;
+    they will be handled by the largest-connected-component fallback in
+    `spectral_communities`.
+
+    Args:
+        systems: List of dicts with `system_id` — used to populate nodes.
+        gate_edges: Iterable of (source_system_id, dest_system_id) pairs.
+
+    Returns:
+        Undirected `networkx.Graph`.
+    """
+    g = nx.Graph()
+    for s in systems:
+        g.add_node(s["system_id"], x=s["x"], z=s["z"])
+    for u, v in gate_edges:
+        if g.has_node(u) and g.has_node(v) and u != v:
+            g.add_edge(u, v)
+    return g
+
+
+def compute_regions(
+    graph: nx.Graph,
+    systems: list[dict],
+    k: int,
+    min_region_size: int = 5,
+) -> dict:
+    """Partition a system graph into k regions via spectral bisection.
+
+    Args:
+        graph: The system connectivity graph (gate or proximity).
+        systems: List of dicts with `system_id`, `x`, `z` for centroid
+            computation. Must include all nodes in `graph`.
+        k: Target number of regions.
+        min_region_size: Minimum nodes per region (smaller groups are
+            left unsplit).
+
+    Returns:
+        Dict with keys:
+          - `graph_kind`: "gate" or "knn"
+          - `k`: requested number of regions
+          - `n_regions`: actual number produced
+          - `n_systems_assigned`: total systems placed in a region
+          - `regions`: list of region dicts with `id`, `size`, `centroid_x`,
+            `centroid_z`, `member_ids` (capped at 50 for payload size)
+          - `assignment`: full system_id → region_id mapping
+    """
+    if graph.number_of_nodes() == 0:
+        return {
+            "graph_kind": graph.graph.get("kind", "unknown"),
+            "k": k,
+            "n_regions": 0,
+            "n_systems_assigned": 0,
+            "regions": [],
+            "assignment": {},
+        }
+
+    # Handle disconnected graphs: partition each connected component
+    # separately, allocating k budget proportional to component size.
+    # Isolated singletons become their own tiny community.
+    components = [graph.subgraph(c).copy() for c in nx.connected_components(graph)]
+    if len(components) == 1:
+        communities = spectral_communities(graph, k=k, min_community_size=min_region_size)
+    else:
+        total_nodes = sum(c.number_of_nodes() for c in components)
+        communities = []
+        remaining_k = k
+        for i, comp in enumerate(components):
+            is_last = i == len(components) - 1
+            if is_last:
+                sub_k = remaining_k
+            else:
+                sub_k = max(1, round(k * comp.number_of_nodes() / total_nodes))
+                sub_k = min(sub_k, remaining_k - (len(components) - 1 - i))
+                sub_k = max(1, sub_k)
+            remaining_k -= sub_k
+            if comp.number_of_nodes() == 1 or sub_k <= 1:
+                communities.append(frozenset(comp.nodes()))
+            else:
+                communities.extend(
+                    spectral_communities(comp, k=sub_k, min_community_size=min_region_size)
+                )
+
+    # Build centroid index from systems list
+    coords = {s["system_id"]: (s["x"], s["z"]) for s in systems}
+
+    assignment: dict[str, int] = {}
+    regions: list[dict] = []
+    for region_id, members in enumerate(communities):
+        member_list = sorted(members)
+        xs = [coords[m][0] for m in member_list if m in coords]
+        zs = [coords[m][1] for m in member_list if m in coords]
+        if not xs or not zs:
+            continue
+        cx = sum(xs) / len(xs)
+        cz = sum(zs) / len(zs)
+        for m in member_list:
+            assignment[m] = region_id
+        # Farthest system from centroid (region "radius")
+        radius = 0.0
+        for m in member_list:
+            if m not in coords:
+                continue
+            dx = coords[m][0] - cx
+            dz = coords[m][1] - cz
+            d = math.sqrt(dx * dx + dz * dz)
+            if d > radius:
+                radius = d
+        regions.append(
+            {
+                "id": region_id,
+                "size": len(member_list),
+                "centroid_x": cx,
+                "centroid_z": cz,
+                "radius": radius,
+                "member_ids": member_list[:50],  # cap for payload
+            }
+        )
+
+    return {
+        "graph_kind": graph.graph.get("kind", "unknown"),
+        "k": k,
+        "n_regions": len(regions),
+        "n_systems_assigned": len(assignment),
+        "regions": regions,
+        "assignment": assignment,
+    }
+
+
+def clear_regions_cache() -> None:
+    """Clear the regions cache. Used by tests."""
+    _region_cache.clear()
+
+
+@router.get("")
+def get_regions(
+    request: Request,
+    k: int = Query(8, ge=2, le=32, description="Target number of regions"),
+    graph_kind: str = Query(
+        "knn",
+        pattern="^(knn|gate)$",
+        description="Graph type: 'knn' (spatial proximity) or 'gate' (stargate topology)",
+    ),
+    knn_k: int = Query(3, ge=1, le=10, description="Neighbors per node for knn graph"),
+    min_region_size: int = Query(5, ge=1, le=100),
+) -> dict:
+    """Partition the galaxy into k spectral regions.
+
+    Returns a deterministic, parameter-free community decomposition of the
+    system graph using `arete-graph-utils.spectral_communities`. Cached
+    for 1 hour by (k, graph_kind) because the computation is non-trivial
+    on 10K+ node graphs.
+    """
+    cache_key = (k, graph_kind)
+    now = time.time()
+    cached = _region_cache.get(cache_key)
+    if cached is not None and (now - cached[0]) < _REGION_CACHE_TTL:
+        return cached[1]
+
+    conn = _get_db(request)
+
+    # Load background systems from reference_data (same source as /api/map/systems)
+    from backend.api.stats import _load_bg_systems
+
+    raw_systems = _load_bg_systems(conn)
+    if not raw_systems:
+        return {
+            "graph_kind": graph_kind,
+            "k": k,
+            "n_regions": 0,
+            "n_systems_assigned": 0,
+            "regions": [],
+            "assignment": {},
+            "note": "No background systems loaded",
+        }
+
+    # Build the graph
+    if graph_kind == "knn":
+        graph = build_knn_graph(raw_systems, k=knn_k)
+    else:
+        # For gate graph we'd need access to the WatchTower /topology response
+        # or a local gate-links table. For now, fall back to knn with a note.
+        graph = build_knn_graph(raw_systems, k=knn_k)
+        graph.graph["note"] = "Gate topology fallback to knn"
+    graph.graph["kind"] = graph_kind
+
+    logger.info(
+        "Computing %d regions on %s graph (|V|=%d, |E|=%d)",
+        k,
+        graph_kind,
+        graph.number_of_nodes(),
+        graph.number_of_edges(),
+    )
+    result = compute_regions(graph, raw_systems, k=k, min_region_size=min_region_size)
+    _region_cache[cache_key] = (now, result)
+    return result

--- a/backend/detection/governance_checker.py
+++ b/backend/detection/governance_checker.py
@@ -90,9 +90,7 @@ class GovernanceChecker(BaseChecker):
                 parsed = raw
 
             parsed_json = parsed.get("parsedJson", parsed)
-            to_addr = self._extract_address(
-                parsed_json, "recipient", "to", "newOwner"
-            )
+            to_addr = self._extract_address(parsed_json, "recipient", "to", "newOwner")
             if not to_addr:
                 continue
 
@@ -132,9 +130,7 @@ class GovernanceChecker(BaseChecker):
                             source_type="chain_event",
                             source_id=t.get("transaction_hash", ""),
                             timestamp=t.get("timestamp", 0),
-                            derivation=(
-                                f"GV1: OwnerCap transfer #{i + 1} to {recipient[:16]}"
-                            ),
+                            derivation=(f"GV1: OwnerCap transfer #{i + 1} to {recipient[:16]}"),
                         )
                         for i, t in enumerate(transfers[:5])
                     ],
@@ -179,9 +175,7 @@ class GovernanceChecker(BaseChecker):
 
             assembly_id = event.get("object_id", "")
             parsed_json = parsed.get("parsedJson", parsed)
-            depositor = self._extract_address(
-                parsed_json, "sender", "owner", "from", "depositor"
-            )
+            depositor = self._extract_address(parsed_json, "sender", "owner", "from", "depositor")
             if not assembly_id or not depositor:
                 continue
 
@@ -264,9 +258,7 @@ class GovernanceChecker(BaseChecker):
                 parsed = raw
 
             parsed_json = parsed.get("parsedJson", parsed)
-            operator = self._extract_address(
-                parsed_json, "sender", "owner", "creator"
-            )
+            operator = self._extract_address(parsed_json, "sender", "owner", "creator")
             if not operator:
                 # Fall back to object owner from objects table
                 obj_id = event.get("object_id", "")

--- a/backend/ingestion/fta_poller.py
+++ b/backend/ingestion/fta_poller.py
@@ -30,26 +30,14 @@ import httpx
 logger = logging.getLogger(__name__)
 
 # FTA deployed addresses (Stillness testnet)
-FTA_PACKAGE_ID = (
-    "0x4d22d8e0cdc3fe27249f1f7ffb8a0b721ea32c80d33817e9fe394de07c771965"
-)
-FTA_OBJECT_ID = (
-    "0x9f68faee73d9817cbf96ea86a0674465731e79da647466a5fe38242816225fc4"
-)
+FTA_PACKAGE_ID = "0x4d22d8e0cdc3fe27249f1f7ffb8a0b721ea32c80d33817e9fe394de07c771965"
+FTA_OBJECT_ID = "0x9f68faee73d9817cbf96ea86a0674465731e79da647466a5fe38242816225fc4"
 
 # FTA sub-table IDs for targeted polling
-FTA_GATE_REGISTRY_TABLE = (
-    "0xda486d92d86793b2987a5edeef2f137cba7ca5f3cef207ec9b49826daa8af8fe"
-)
-FTA_BLACKLIST_TABLE = (
-    "0x7ac35342d6d6dfec9e4da0dc64cbdfef78ee5fb6b58c4785f5839ed20d415651"
-)
-FTA_BOUNTY_CHARACTER_TABLE = (
-    "0x2c5e9c125d7f67b28850b89026a12968f7d562a58bb9a7ecc1d29bbabfa1efbd"
-)
-FTA_JUMP_HISTORY_TABLE = (
-    "0x8137286a1bd2b7f1507b1369e1c31ca05835ce99a7e2f055659f08b598a17d94"
-)
+FTA_GATE_REGISTRY_TABLE = "0xda486d92d86793b2987a5edeef2f137cba7ca5f3cef207ec9b49826daa8af8fe"
+FTA_BLACKLIST_TABLE = "0x7ac35342d6d6dfec9e4da0dc64cbdfef78ee5fb6b58c4785f5839ed20d415651"
+FTA_BOUNTY_CHARACTER_TABLE = "0x2c5e9c125d7f67b28850b89026a12968f7d562a58bb9a7ecc1d29bbabfa1efbd"
+FTA_JUMP_HISTORY_TABLE = "0x8137286a1bd2b7f1507b1369e1c31ca05835ce99a7e2f055659f08b598a17d94"
 
 SUI_GRAPHQL_URL = "https://graphql.testnet.sui.io/graphql"
 
@@ -144,9 +132,7 @@ class FTAPoller:
 
     def _get_state(self, key: str, default: str = "") -> str:
         """Get persisted FTA poller state."""
-        row = self.conn.execute(
-            "SELECT value FROM fta_state WHERE key = ?", (key,)
-        ).fetchone()
+        row = self.conn.execute("SELECT value FROM fta_state WHERE key = ?", (key,)).fetchone()
         if row:
             return row[0] if isinstance(row, tuple) else row["value"]
         return default
@@ -237,19 +223,11 @@ class FTAPoller:
 
             # Process object changes (gate reg/dereg, bounty, blacklist)
             obj_changes = effects.get("objectChanges", {}).get("nodes", [])
-            created_ids = [
-                o["address"] for o in obj_changes
-                if o.get("idCreated")
-            ]
-            deleted_ids = [
-                o["address"] for o in obj_changes
-                if o.get("idDeleted")
-            ]
+            created_ids = [o["address"] for o in obj_changes if o.get("idCreated")]
+            deleted_ids = [o["address"] for o in obj_changes if o.get("idDeleted")]
 
             # FTA object was mutated — record version change
-            fta_mutated = any(
-                o["address"] == FTA_OBJECT_ID for o in obj_changes
-            )
+            fta_mutated = any(o["address"] == FTA_OBJECT_ID for o in obj_changes)
             if fta_mutated and (created_ids or deleted_ids):
                 event_count += self._store_fta_event(
                     event_type="FTA_StateMutation",
@@ -270,7 +248,10 @@ class FTAPoller:
         if event_count:
             logger.info(
                 "FTA poller: %d events from %d transactions (checkpoint %s→%s)",
-                event_count, len(nodes), last_checkpoint, max_checkpoint,
+                event_count,
+                len(nodes),
+                last_checkpoint,
+                max_checkpoint,
             )
 
         return event_count
@@ -301,9 +282,7 @@ class FTAPoller:
             return False  # No change
 
         # Extract key metrics from object contents
-        contents = (
-            obj.get("asMoveObject", {}).get("contents", {}).get("json", {})
-        )
+        contents = obj.get("asMoveObject", {}).get("contents", {}).get("json", {})
         snapshot = {
             "version": version,
             "developer_balance": contents.get("developer_balance", "0"),
@@ -316,7 +295,9 @@ class FTAPoller:
 
         logger.info(
             "FTA snapshot: version %s → %s, dev_balance=%s",
-            last_version, version, snapshot["developer_balance"],
+            last_version,
+            version,
+            snapshot["developer_balance"],
         )
         return True
 

--- a/backend/ingestion/world_poller.py
+++ b/backend/ingestion/world_poller.py
@@ -237,9 +237,7 @@ class WorldPoller:
         # Skip if tribes were loaded within the last 24 hours
         existing = self.conn.execute("SELECT COUNT(*) FROM tribe_cache").fetchone()[0]
         if existing > 0:
-            row = self.conn.execute(
-                "SELECT MAX(last_confirmed_at) FROM tribe_cache"
-            ).fetchone()
+            row = self.conn.execute("SELECT MAX(last_confirmed_at) FROM tribe_cache").fetchone()
             age = time.time() - row[0] if row and row[0] is not None else 0
             if age < 86400:
                 return 0

--- a/backend/main.py
+++ b/backend/main.py
@@ -38,6 +38,7 @@ from backend.api.objects import router as objects_router
 from backend.api.orbital_zones import router as orbital_zones_router
 from backend.api.public import limiter
 from backend.api.public import router as public_router
+from backend.api.regions import router as regions_router
 from backend.api.reports import router as reports_router
 from backend.api.stats import router as stats_router
 from backend.api.status import router as status_router
@@ -877,6 +878,7 @@ app.include_router(anomalies_router)
 app.include_router(reports_router)
 app.include_router(objects_router)
 app.include_router(stats_router)
+app.include_router(regions_router)
 app.include_router(submit_router)
 app.include_router(systems_router)
 app.include_router(subscriptions_router)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
     "anthropic>=0.43.0",
     "aiosqlite>=0.20.0",
     "slowapi>=0.1.9",
+    "networkx>=3.0",
+    "arete-graph-utils @ git+https://github.com/AreteDriver/arete-graph-utils.git@main",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_api/test_regions_api.py
+++ b/tests/test_api/test_regions_api.py
@@ -1,0 +1,245 @@
+"""Tests for the spectral regions API endpoint.
+
+The regions endpoint partitions the galaxy's background systems into k
+communities via `arete-graph-utils.spectral_communities`. These tests
+verify the partitioning logic, caching, and graph-building helpers
+without depending on a populated WatchTower topology cache.
+"""
+
+import json
+
+import networkx as nx
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.api.regions import (
+    build_gate_graph,
+    build_knn_graph,
+    clear_regions_cache,
+    compute_regions,
+)
+from backend.api.stats import clear_map_cache
+from backend.db.database import init_db
+from backend.main import app
+
+
+@pytest.fixture
+def client():
+    conn = init_db(":memory:")
+    app.state.db = conn
+    clear_regions_cache()
+    clear_map_cache()
+    # Also clear the bg_systems cache in stats (module-level)
+    from backend.api import stats as stats_module
+
+    stats_module._bg_systems_cache = None
+    stats_module._bg_systems_etag = None
+    stats_module._bg_bounds = None
+    yield TestClient(app, raise_server_exceptions=False)
+    conn.close()
+
+
+def _insert_system(conn, sid: str, name: str, x: int, z: int) -> None:
+    data_json = json.dumps(
+        {
+            "name": name,
+            "location": {"x": x, "y": 0, "z": z},
+        }
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO reference_data (data_type, data_id, name, data_json) "
+        "VALUES (?, ?, ?, ?)",
+        ("solarsystems", sid, name, data_json),
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# build_knn_graph
+# ---------------------------------------------------------------------------
+
+
+class TestBuildKnnGraph:
+    def test_empty_systems_returns_empty_graph(self):
+        g = build_knn_graph([])
+        assert g.number_of_nodes() == 0
+        assert g.number_of_edges() == 0
+
+    def test_single_system_has_no_edges(self):
+        g = build_knn_graph([{"system_id": "s1", "x": 0, "z": 0}])
+        assert g.number_of_nodes() == 1
+        assert g.number_of_edges() == 0
+
+    def test_knn_graph_has_all_systems_as_nodes(self):
+        systems = [{"system_id": f"s{i}", "x": i * 10, "z": 0} for i in range(6)]
+        g = build_knn_graph(systems, k=2)
+        assert g.number_of_nodes() == 6
+        for s in systems:
+            assert g.has_node(s["system_id"])
+
+    def test_knn_connects_nearest_neighbors(self):
+        # 3 systems on a line; k=1 connects each to its nearest neighbor
+        systems = [
+            {"system_id": "A", "x": 0, "z": 0},
+            {"system_id": "B", "x": 10, "z": 0},
+            {"system_id": "C", "x": 100, "z": 0},
+        ]
+        g = build_knn_graph(systems, k=1)
+        assert g.has_edge("A", "B")
+        # C's nearest is B, so edge B-C must exist
+        assert g.has_edge("B", "C")
+
+    def test_knn_k_clamped_to_max_possible(self):
+        # Only 3 systems — requesting k=10 should not crash
+        systems = [{"system_id": f"s{i}", "x": i, "z": 0} for i in range(3)]
+        g = build_knn_graph(systems, k=10)
+        # All 3 systems should be mutually connected (complete graph)
+        assert g.number_of_edges() == 3
+
+
+# ---------------------------------------------------------------------------
+# build_gate_graph
+# ---------------------------------------------------------------------------
+
+
+class TestBuildGateGraph:
+    def test_gate_graph_uses_provided_edges(self):
+        systems = [
+            {"system_id": "A", "x": 0, "z": 0},
+            {"system_id": "B", "x": 100, "z": 100},
+            {"system_id": "C", "x": 200, "z": 200},
+        ]
+        edges = [("A", "B"), ("B", "C")]
+        g = build_gate_graph(systems, edges)
+        assert g.has_edge("A", "B")
+        assert g.has_edge("B", "C")
+        assert not g.has_edge("A", "C")
+
+    def test_gate_graph_ignores_edges_to_unknown_systems(self):
+        systems = [{"system_id": "A", "x": 0, "z": 0}]
+        edges = [("A", "X")]  # X doesn't exist
+        g = build_gate_graph(systems, edges)
+        assert g.number_of_edges() == 0
+
+    def test_gate_graph_ignores_self_loops(self):
+        systems = [{"system_id": "A", "x": 0, "z": 0}]
+        edges = [("A", "A")]
+        g = build_gate_graph(systems, edges)
+        assert g.number_of_edges() == 0
+
+
+# ---------------------------------------------------------------------------
+# compute_regions
+# ---------------------------------------------------------------------------
+
+
+class TestComputeRegions:
+    def test_empty_graph_returns_empty_result(self):
+        result = compute_regions(nx.Graph(), [], k=4)
+        assert result["n_regions"] == 0
+        assert result["regions"] == []
+
+    def test_two_clusters_recovered_as_two_regions(self):
+        # Two K3 cliques connected by a bridge
+        systems = [{"system_id": f"s{i}", "x": i * 10, "z": 0} for i in range(6)]
+        g = nx.Graph()
+        for s in systems:
+            g.add_node(s["system_id"])
+        # Cluster 1: s0-s1-s2
+        g.add_edges_from([("s0", "s1"), ("s1", "s2"), ("s0", "s2")])
+        # Cluster 2: s3-s4-s5
+        g.add_edges_from([("s3", "s4"), ("s4", "s5"), ("s3", "s5")])
+        # Bridge
+        g.add_edge("s2", "s3")
+
+        result = compute_regions(g, systems, k=2, min_region_size=2)
+        assert result["n_regions"] == 2
+        # Each region has exactly 3 members
+        assert sorted(r["size"] for r in result["regions"]) == [3, 3]
+
+    def test_all_systems_assigned_to_a_region(self):
+        systems = [{"system_id": f"s{i}", "x": i, "z": i} for i in range(8)]
+        g = build_knn_graph(systems, k=2)
+        result = compute_regions(g, systems, k=3, min_region_size=1)
+        assert result["n_systems_assigned"] == 8
+        assert set(result["assignment"].keys()) == {f"s{i}" for i in range(8)}
+
+    def test_centroids_computed_from_member_coordinates(self):
+        systems = [
+            {"system_id": "a", "x": 0, "z": 0},
+            {"system_id": "b", "x": 10, "z": 0},
+            {"system_id": "c", "x": 1000, "z": 1000},
+            {"system_id": "d", "x": 1010, "z": 1000},
+        ]
+        g = nx.Graph()
+        for s in systems:
+            g.add_node(s["system_id"])
+        g.add_edge("a", "b")
+        g.add_edge("c", "d")
+        # Bridge to make graph connected
+        g.add_edge("b", "c")
+
+        result = compute_regions(g, systems, k=2, min_region_size=2)
+        centroids = sorted((r["centroid_x"], r["centroid_z"]) for r in result["regions"])
+        # One centroid near (5, 0), one near (1005, 1000)
+        assert centroids[0][0] < 500
+        assert centroids[1][0] > 500
+
+
+# ---------------------------------------------------------------------------
+# /api/map/regions endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestRegionsEndpoint:
+    def test_empty_db_returns_empty_regions(self, client):
+        response = client.get("/api/map/regions?k=4")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["n_regions"] == 0
+        assert data["regions"] == []
+
+    def test_partition_with_k_regions(self, client):
+        conn = app.state.db
+        # Insert 12 systems in three spatial clusters
+        clusters = [
+            [(1000, 1000), (1010, 1000), (1000, 1010), (1010, 1010)],
+            [(5000, 5000), (5010, 5000), (5000, 5010), (5010, 5010)],
+            [(9000, 9000), (9010, 9000), (9000, 9010), (9010, 9010)],
+        ]
+        idx = 0
+        for cluster in clusters:
+            for x, z in cluster:
+                _insert_system(conn, f"sys-{idx}", f"Sys {idx}", x, z)
+                idx += 1
+
+        response = client.get("/api/map/regions?k=3&knn_k=2&min_region_size=2")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["k"] == 3
+        assert data["n_regions"] >= 2  # At least 2 regions recovered
+        assert data["n_systems_assigned"] == 12
+
+    def test_response_caching(self, client):
+        conn = app.state.db
+        for i in range(6):
+            _insert_system(conn, f"s{i}", f"Sys {i}", i * 1000, i * 1000)
+
+        # First call populates the cache
+        r1 = client.get("/api/map/regions?k=2&knn_k=1&min_region_size=1")
+        assert r1.status_code == 200
+        # Second call is served from cache — identical bytes
+        r2 = client.get("/api/map/regions?k=2&knn_k=1&min_region_size=1")
+        assert r2.status_code == 200
+        assert r1.json() == r2.json()
+
+    def test_k_parameter_validated(self, client):
+        # k=1 is below minimum, k=100 is above maximum
+        r1 = client.get("/api/map/regions?k=1")
+        assert r1.status_code == 422
+        r2 = client.get("/api/map/regions?k=100")
+        assert r2.status_code == 422
+
+    def test_graph_kind_validated(self, client):
+        response = client.get("/api/map/regions?k=4&graph_kind=invalid")
+        assert response.status_code == 422


### PR DESCRIPTION
## Summary

Adds `/api/map/regions`, a parameter-free spectral partitioning of the galaxy's background systems into k communities via Fiedler bisection from the new [arete-graph-utils](https://github.com/AreteDriver/arete-graph-utils) package (distilled from the Prima Materia research).

Replaces hand-drawn region boundaries with a reproducible, adaptive decomposition that tracks actual connectivity structure. Computed server-side, cached 1h by (k, graph_kind), 8 regions by default.

## What's new

- `backend/api/regions.py` — new FastAPI router
  - `build_knn_graph(systems, k)` — k-nearest-neighbors proximity graph on (x, z) coordinates
  - `build_gate_graph(systems, edges)` — explicit gate-topology graph from edge list
  - `compute_regions(graph, systems, k)` — partitions via `spectral_communities`, computes centroid + radius per region, handles disconnected graphs by allocating k proportionally per connected component
  - `GET /api/map/regions?k=8&graph_kind=knn&knn_k=3&min_region_size=5` — cached endpoint
- `backend/main.py` — register `regions_router` after `stats_router`
- `pyproject.toml` — adds `networkx>=3.0` and `arete-graph-utils @ git+https://github.com/AreteDriver/arete-graph-utils.git@main` (will switch to PyPI version once published)

## Algorithm

1. Load background systems from `reference_data` (reuses existing `_load_bg_systems` cache).
2. Build a graph — `knn` (spatial proximity) or `gate` (stargate topology; currently falls back to knn until WatchTower topology caching is plumbed through).
3. Partition with `arete_graph_utils.spectral_communities(k, min_community_size)`, which runs recursive Fiedler bisection on each connected component.
4. Compute centroid, radius, and member list per region.
5. Return `{graph_kind, k, n_regions, n_systems_assigned, regions, assignment}`.

## Tests

17 new tests in `tests/test_api/test_regions_api.py`:

- `TestBuildKnnGraph` (5): empty, single node, node count, nearest-neighbor correctness, k clamping
- `TestBuildGateGraph` (3): explicit edges, unknown systems filtered, self-loops rejected
- `TestComputeRegions` (4): empty graph, clique recovery, all-systems-assigned, centroid accuracy
- `TestRegionsEndpoint` (5): empty DB, full partition run, response caching, query parameter validation

**Full regression:** 654/654 tests passing (637 existing + 17 new).
**Ruff:** clean on `backend/ tests/`.

## Test plan

- [x] `pytest tests/ -x -q --no-cov` — 654 passing
- [x] `ruff check backend/ tests/` — clean
- [x] Endpoint responds 200 on empty DB
- [x] Partition correctly assigns all 12 systems in a 3-cluster stress test
- [ ] Manual: hit `/api/map/regions?k=8` on production DB after deploy, verify 8 regions, confirm centroids look sensible when overlaid on the map

## Related

- `arete-graph-utils` package: https://github.com/AreteDriver/arete-graph-utils
- Prima Materia research (where these utilities were first validated): https://github.com/AreteDriver/prima-materia

🤖 Generated with [Claude Code](https://claude.com/claude-code)